### PR TITLE
Add native token swap support

### DIFF
--- a/src/components/Balance/SwapModal.tsx
+++ b/src/components/Balance/SwapModal.tsx
@@ -61,19 +61,25 @@ export const SwapModal = ({ currencyInfo, closeModal }: SwapModalProps) => {
       }
 
       // Approve
-      const approveTxHash = await walletClient.sendTransaction({
-        to: swapQuote.currencyAddress as `0x${string}`,
-        data: swapQuote.approveData as `0x${string}`
-      })
-      await publicClient.waitForTransactionReceipt({
-        hash: approveTxHash,
-        confirmations: 1
-      })
+      if (swapQuote.approveData) {
+        const approveTxHash = await walletClient.sendTransaction({
+          to: swapQuote.currencyAddress as `0x${string}`,
+          data: swapQuote.approveData as `0x${string}`
+        })
+        await publicClient.waitForTransactionReceipt({
+          hash: approveTxHash,
+          confirmations: 1
+        })
+      }
 
       // Swap
+      // Hack until api changes upstream are merged
+      type SwapQuoteWithTransactionValue = SwapQuote & { transactionValue?: string }
+      const swapWithValue = swapQuote as SwapQuoteWithTransactionValue
       const swapTxHash = await walletClient.sendTransaction({
         to: swapQuote.to as `0x${string}`,
-        data: swapQuote.transactionData as `0x${string}`
+        data: swapQuote.transactionData as `0x${string}`,
+        value: BigInt(swapWithValue.transactionValue || 0)
       })
       await publicClient.waitForTransactionReceipt({
         hash: swapTxHash,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,12 @@
 // sales params
 export const NFT_TOKEN_ADDRESS = '0xe330d543e9189450c36dc873aa3ab14106b1ee87'
 export const SALES_CONTRACT_ADDRESS = '0xfdd0d596350a78c3852a43d3b5910154b7c644db'
+export const FAUX_NATIVE_TOKEN_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
+export const NATIVE_TOKEN_DETAILS = {
+  name: 'Ether',
+  symbol: 'ETH'
+}
+export const WETH_CONTRACT_ADDRESS = '0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14'
 export const CHAIN_ID = 11155111
 export const ETHERSCAN_URL = 'https://sepolia.etherscan.io'
 export const SWAP_CURRENCY = {

--- a/src/hooks/data.ts
+++ b/src/hooks/data.ts
@@ -6,6 +6,7 @@ import { ContractInfo, SequenceMetadata } from '@0xsequence/metadata'
 import { useAPIClient } from '../hooks/useAPIClient'
 import { useIndexerClient } from '../hooks/useIndexerClient'
 import { useMetadataClient } from '../hooks/useMetadataClient'
+import { FAUX_NATIVE_TOKEN_ADDRESS, NATIVE_TOKEN_DETAILS } from '../constants'
 
 export const time = {
   oneSecond: 1 * 1000,
@@ -107,9 +108,14 @@ interface UseSwapQuotesArgs {
   withContractInfo?: boolean
 }
 
+type MinimalContractInfo = {
+  name: string
+  symbol: string
+}
+
 type SwapQuotesWithCurrencyInfo = {
   quote: SwapQuote
-  info: ContractInfo | undefined
+  info: MinimalContractInfo | undefined
 }
 
 const getSwapQuotes = async (
@@ -140,10 +146,17 @@ const getSwapQuotes = async (
     })
   }
 
+  const getCurrencyInfoFromMap = async (currencyAddress: string): Promise<MinimalContractInfo | undefined> => {
+    if (currencyAddress.toLowerCase() === FAUX_NATIVE_TOKEN_ADDRESS.toLowerCase()) {
+      return NATIVE_TOKEN_DETAILS
+    }
+    return await currencyInfoMap.get(currencyAddress)
+  }
+
   return Promise.all(
     res?.swapQuotes.map(async quote => ({
       quote,
-      info: (await currencyInfoMap.get(quote.currencyAddress)) || undefined
+      info: (await getCurrencyInfoFromMap(quote.currencyAddress)) || undefined
     })) || []
   )
 }


### PR DESCRIPTION
Please note, this includes a type hack for support. Once API changes are merged upstream the extra type can be removed. This also won't work until said changes are in production. (You can test with a local API instance). 